### PR TITLE
Adding the ability to include release notes

### DIFF
--- a/.github/workflows/reusable-draft-new-release-workflow.yml
+++ b/.github/workflows/reusable-draft-new-release-workflow.yml
@@ -6,6 +6,9 @@ on:
       semver:
         required: true
         type: string
+      note:
+        required: false
+        type: string
     secrets:
       GH_TOKEN:
         required: true
@@ -35,8 +38,7 @@ jobs:
           git add package.json
           git add package-lock.json
           git commit --message "Prepare release ${{ env.PACKAGE_VERSION }}"
-
-          echo "::set-output name=commit::$(git rev-parse HEAD)"
+          echo "::set-output name=commit::$(git rev-parse HEAD)
 
       - name: Push new branch
         run: git push origin release/${{ env.PACKAGE_VERSION }}
@@ -57,3 +59,18 @@ jobs:
             I've updated versions in the package.json in this commit: ${{ steps.make-commit.outputs.commit }}.
 
             Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.
+
+            Release Notes:
+            ${{ inputs.note }}
+
+      - name: Make note
+        run: |
+          mkdir -p ~/tmp/notes
+          echo ${{ inputs.note }} >> ~/tmp/notes/note-${{ env.PACKAGE_VERSION }}.txt
+          cat ~/tmp/notes/note-${{ env.PACKAGE_VERSION }}.txt
+
+      - name: Cache note
+        uses: actions/cache@v2
+        with:
+          path: ~/tmp/notes
+          key: notes-${{ env.PACKAGE_VERSION }}

--- a/.github/workflows/reusable-publish-new-release-workflow.yml
+++ b/.github/workflows/reusable-publish-new-release-workflow.yml
@@ -19,7 +19,6 @@ jobs:
         run: |
           BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           VERSION=${BRANCH_NAME#release/}
-
           echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Extract version from branch name (for hotfix branches)
@@ -27,8 +26,20 @@ jobs:
         run: |
           BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           VERSION=${BRANCH_NAME#hotfix/}
-
           echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Load cache
+        id: cache-notes
+        uses: actions/cache@v2
+        with:
+          path: ~/tmp/notes
+          key: notes-${{ env.RELEASE_VERSION }}
+
+      - name: Get note from cache
+        if: steps.cache-notes.outputs.cache-hit != 'false'
+        run: |
+          echo ~/tmp/notes/note.txt
+          echo "RELEASE_NOTE=$(cat ~/tmp/notes/note-${{ env.RELEASE_VERSION }}.txt)" >> $GITHUB_ENV
 
       - name: Create Release
         if: ${{ env.RELEASE_VERSION }}
@@ -39,6 +50,7 @@ jobs:
           target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
           tag_name: v${{ env.RELEASE_VERSION }}
           name: v${{ env.RELEASE_VERSION }}
+          body: ${{ env.RELEASE_NOTE }}
           draft: false
           prerelease: false
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ on:
         - minor
         - major
         required: true
+      note:
+        type: string
+        description: Note to add to the release
+        required: false
 
 jobs:
   draft-release:


### PR DESCRIPTION
Adding release notes to the github actions.
This is a non-breaking change, if there are no notes the action defaults to the previous behaviour, the only difference will be the draft release PR which will include release notes with a blank line

![image](https://user-images.githubusercontent.com/3177752/187684358-98896d39-259f-4941-b561-52b1285f55f4.png)

Example repo using actions with notes: https://github.com/doddle/drone-tests/actions/workflows/draft-release.yml